### PR TITLE
Fix hydra project rendering

### DIFF
--- a/content/projects.yaml
+++ b/content/projects.yaml
@@ -251,7 +251,7 @@ projects:
      
   -   
      name: 'The Gap Game'
-     description: Incentive analysis in a PoW cryptocurrency, where transaction fees play a dominant role. We analyze suck systems as a game and show (&quot;mining gaps&quot;) occur - periods of time where miners are incentivized to be idle instead of actively mining. We also show in such systems, miners are better off forming coalitions, which leads to a centralized system. For more info, please see our <a href="https://dl.acm.org/citation.cfm?id=3243737">paper<a/>.
+     description: Incentive analysis in a PoW cryptocurrency, where transaction fees play a dominant role. We analyze suck systems as a game and show (&quot;mining gaps&quot;) occur - periods of time where miners are incentivized to be idle instead of actively mining. We also show in such systems, miners are better off forming coalitions, which leads to a centralized system. For more info, please see our <a href="https://dl.acm.org/citation.cfm?id=3243737">paper</a>.
 
   -  
     name: 'The Hydra Project'


### PR DESCRIPTION
The previous yaml block was ending with <a/> instead of </a>, which was
causing the hydra yaml block not to render properly.